### PR TITLE
Encode url params to enable "/" in appNames

### DIFF
--- a/src/import-map/import-map.component.js
+++ b/src/import-map/import-map.component.js
@@ -60,7 +60,7 @@ export default function ImportMap(props) {
           </Link>
           {applications.length > 0 && (
             <Link
-              to={`/app/${applications[0].name}`}
+              to={`/app/${encodeURIComponent(applications[0].name)}`}
               className="primary button"
             >
               Next step: test it out

--- a/src/navbars/sidebar.component.js
+++ b/src/navbars/sidebar.component.js
@@ -69,7 +69,7 @@ export default function Sidebar(props) {
           <div key={app.name}>
             <li>
               <NavLink
-                to={`/app/${app.name}`}
+                to={`/app/${encodeURIComponent(app.name)}`}
                 className="nav-link"
                 activeClassName="active"
                 onClick={maybeHideSidebar}

--- a/src/test-app/test-app.component.js
+++ b/src/test-app/test-app.component.js
@@ -23,7 +23,9 @@ const stepComponents = [
 
 export default function TestApp(props) {
   const { applications } = useContext(LocalStorageContext);
-  const app = applications.find(a => a.name === props.match.params.appName);
+  const app = applications.find(
+    a => a.name === decodeURIComponent(props.match.params.appName)
+  );
   const scope = useCss(css);
   const nextTestRef = useRef(null);
   const [nextTestIndex, setNextTestIndex] = useState(0);


### PR DESCRIPTION
As described in the issue #17 I think the main problem is Single-SPA with scoped package names (ex: @react-mf/people).
Enconding and decoding `:appName` urlParams when generating Link/Navlink and when TestPage is rendered, may be enough to fix this problem!
