### PR TITLE
Add react and react-dom in root importmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,11 @@
       {
         "imports": {
           "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@5.1.1/lib/system/single-spa.min.js",
-          "single-spa-playground": "/assets/single-spa-playground.js"
+          "single-spa-playground": "/assets/single-spa-playground.js",
+          "react": "https://cdn.jsdelivr.net/npm/react@16.13.0/umd/react.production.min.js",
+          "react-dom": "https://cdn.jsdelivr.net/npm/react-dom@16.13.0/umd/react-dom.production.min.js",
+          "vue-router": "https://cdn.jsdelivr.net/npm/vue-router@3.1.6/dist/vue-router.min.js",
+          "vue": "https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js"
         }
       }
     </script>


### PR DESCRIPTION
Implements #21 
Add dependencies in playground root import-map so s-spa applications with `react` and `react-dom` as externals can work.
Also added `vue` and  `vue-router`.

## Problems
The create-single-spa cli for react app is working flawlessly, but the others creates a regular vue/angular applications without single-spa-vue/angular wrappers.
Testing was made using https://vue.microfrontends.app/rate-doggos app