### PR TITLE
Fix/systemjsmodule appdependencies regex

### DIFF
--- a/src/shared/use-app-shared-deps.hook.js
+++ b/src/shared/use-app-shared-deps.hook.js
@@ -6,7 +6,7 @@ export const getAppDependencies = ({ name, url }) => {
   return fetch(fetchUrl)
     .then((resp) => resp.text())
     .then((jsBundleStringified) => {
-      const systemjsModule = /^System\.register\((\[.+?\])/;
+      const systemjsModule = /^System\.register\((\[.*?\])/;
       const amdModule = /define\((\[.+?\])/;
       const match =
         jsBundleStringified.match(systemjsModule) ||

--- a/src/shared/use-app-shared-deps.hook.js
+++ b/src/shared/use-app-shared-deps.hook.js
@@ -12,12 +12,20 @@ export const getAppDependencies = ({ name, url }) => {
         jsBundleStringified.match(systemjsModule) ||
         jsBundleStringified.match(amdModule);
 
+      let appSharedDeps = [];
+
       if (match) {
-        const appSharedDeps = JSON.parse(match[1]);
-        return appSharedDeps;
+        try {
+          appSharedDeps = JSON.parse(match[1]);
+        } catch (err) {
+          console.error(
+            `There was an error parsing the application's shared deps.`,
+            err
+          );
+        }
       }
 
-      return [];
+      return appSharedDeps;
     });
 };
 


### PR DESCRIPTION
I found that the regex for parsing the shared deps array was incorrect if it was empty (eg. `System.register([],(function(e){}))`) ([source](https://github.com/single-spa/create-single-spa/pull/124#issuecomment-631693299)). This PR changes the regex so that it capture zero or many characters, as well as handles if the captured string is unable to be `JSON.parse`d.

To validate this fix:
1. Go to https://regex101.com/
2. Provide `^System\.register\((\[.*?\])`
3. test with an System.register string with an empty array such [this one](https://dist-qqbprggud.now.sh/single-spa-welcome.js)
4. test with a System.register string that has values (just edit the above)

Both should return the array of the System.register call.