### PR TITLE
Include framework from params

### DIFF
--- a/src/instant-test/instant-test.component.js
+++ b/src/instant-test/instant-test.component.js
@@ -11,7 +11,11 @@ export default function InstantTest(props) {
       return;
     }
 
-    const app = { name: params.get("name"), pathPrefix: "/" };
+    const app = {
+      name: params.get("name"),
+      pathPrefix: "/",
+      framework: params.get("framework") || undefined,
+    };
 
     addApplication(app);
 


### PR DESCRIPTION
I'm working on https://github.com/single-spa/create-single-spa/issues/94 and in order to support additional frameworks this param needs to be included to that the application gets set correctly. It was defaulting to React before.