### PR TITLE
Prevent instant-test from rerendering hundreds of times

### DIFF
--- a/src/instant-test/instant-test.component.js
+++ b/src/instant-test/instant-test.component.js
@@ -1,31 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import { LocalStorageContext } from "../shared/use-local-storage-data.hook";
 
 export default function InstantTest(props) {
-  const params = new URLSearchParams(location.search);
-  const isValid = params.has("name") && params.has("url");
+  const [isValid, setIsValid] = useState(true);
   const { addApplication } = React.useContext(LocalStorageContext);
 
   React.useEffect(() => {
-    if (!isValid) {
-      return;
+    const params = new URLSearchParams(location.search);
+
+    if (!(params.has("name") && params.has("url"))) {
+      setIsValid(false);
+    } else {
+      const app = {
+        name: params.get("name"),
+        pathPrefix: "/",
+        framework: params.get("framework") || undefined,
+      };
+
+      addApplication(app);
+
+      window.importMapOverrides.addOverride(
+        params.get("name"),
+        params.get("url")
+      );
+
+      location.assign("/");
     }
-
-    const app = {
-      name: params.get("name"),
-      pathPrefix: "/",
-      framework: params.get("framework") || undefined,
-    };
-
-    addApplication(app);
-
-    window.importMapOverrides.addOverride(
-      params.get("name"),
-      params.get("url")
-    );
-
-    location.assign("/");
-  }, [addApplication, isValid, params]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (isValid) {
     return null;


### PR DESCRIPTION
I found this performance issue when building the instant-test functionality for Angular. The effect that runs to set the application using the URL params is running hundreds of times.

![Screen Shot 2020-06-02 at 3 45 41 PM](https://user-images.githubusercontent.com/4202993/83573485-d1f3b880-a4e8-11ea-82d3-967abe8e31b1.png)

This causes significant slowness when testing the application. This fix makes it so that the effect is run only once.

![Screen Shot 2020-06-02 at 3 47 10 PM](https://user-images.githubusercontent.com/4202993/83573631-1717ea80-a4e9-11ea-8482-aaeb3837cf5b.png)
