### PR TITLE
fix: adjusting z-index on playground style to make it not overlapping…

### DIFF
--- a/src/playground.component.js
+++ b/src/playground.component.js
@@ -50,7 +50,7 @@ export default function Playground(props) {
 const css = `
 & .playground {
   position: absolute;
-  z-index: 88888;
+  z-index: 200;
   top: 0;
   left: 0;
   width: 100vw;


### PR DESCRIPTION
## Hotfix Regarding Override Button Block by Main Wrapper because of z-index value above the override button

### Description
Hello guys, I want to report a finding that I found on Single-SPA playground, So I want to try how Single-SPA playground will guide me to see if my applications works (Actually I can successfully make it works on my local using [Single-SPA Vue Example](https://github.com/vue-microfrontends)). here is the screenshot below

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/d94b03e1-67ec-4edc-b535-ad4603d61583)

because of it, I want to know how it works on playground so I try to play around with it, but turns out, I got stuck when tried to verify it on Step 1 because it always told me that my applications failed because of my `@vue-mf/styleguide`

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/bb95f6fa-d85e-4c2f-aa84-9ebdb5fa71cf)

Curious about it, I see the text above which told me to try using the devtools on the bottom-right corner which is this one

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/1546de34-c368-4261-bc6a-913741a2dd5d)

but when I tried to click it, I always failed to do it, so I think maybe it only show and I need to enable it manually, so I tried to add `devtools: true` on my Local Storage like this

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/7fbcfecc-b604-46d8-8ee5-ff78fec90ba7)

but it seems still failed, So I got curious and tried to inspect it, and turn out it seems the playground main wrapper using `z-index` and and it blocked the override button and make it can't be clicked

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/b1e2323c-3e09-4055-8e28-a9c4cd787e7c)

So when I tried to disabled it, it works and I can click it again to override my styles

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/98597d9c-f6ad-43a0-8e9c-66f690954778)

### What Type of PR is This?
Bug Fix

### Issue Card
https://github.com/single-spa/single-spa-playground/issues/61 - Failed to Override The the Style button because of the main application Z-Index above the button

### Propose Solution
I think we can exclude the z-Index on the playground or at least adjust it so we can use this override button again

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/e5e66d22-1cae-4f75-9e75-6637640c55b2)

so if I stretched my screen it will looks like this

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/bafbc799-34c4-41c5-be73-90aa25214699)

and my fix will make the overlay looks like this

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/350ed861-6e82-4579-a175-17890c21182a)

in current production it will looks like this

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/dc0bf44c-e1dd-45a9-a7bd-8b85586e36a3)

now if the adjust approach is used, user can click it again

![image](https://github.com/single-spa/single-spa-playground/assets/28122968/98946fb7-3dc7-470e-a3fd-1849867c5bbf)

